### PR TITLE
remove unnecessary `internal` modifier, as it refers to a module

### DIFF
--- a/code/kotlin/classes/classes-010.kt
+++ b/code/kotlin/classes/classes-010.kt
@@ -1,3 +1,3 @@
 class Document {
-    internal inner class InnerClass
+    inner class InnerClass
 }


### PR DESCRIPTION
`internal` is not the same as Java's `package-private`. From the docs: 

The internal visibility modifier means that the member is visible with the same module. More specifically, a module is a set of Kotlin files compiled together:  
* an IntelliJ IDEA module;
* a Maven or Gradle project;
* a set of files compiled with one invocation of the Ant task.