### PR TITLE
Replace range with until function that does not include its end element

### DIFF
--- a/code/kotlin/basic/for.kt
+++ b/code/kotlin/basic/for.kt
@@ -1,4 +1,4 @@
-for (i in 1..10) { }
+for (i in 1 until 11) { }
 
 for (i in 1..10 step 2) {}
 


### PR DESCRIPTION
`for-in-until` was included in Kotlin 1.1.4 and it's offers optimizations for right-exclusive loops ([ref.](https://github.com/jetbrains/kotlin/commit/506941e7e0cc118c5679ea2bbabad89eb3f2ee03#diff-553990ab967b96e8bb659cc4ebdea0cc)).

I am opening this PR to change the right-exclusive loop example in Kotlin using `until` instead of ranges.