### PR TITLE
Update null-ii.java to be consistent with kotlin

### DIFF
--- a/code/java/basic/null-ii.java
+++ b/code/java/basic/null-ii.java
@@ -1,3 +1,7 @@
+int length;
 if(text != null){
-  int length = text.length();
+  length = text.length();
+}
+else{
+  length = null;
 }


### PR DESCRIPTION
The kotlin code assigns null to length if text is null.
The old java code declared length in a different scope and never declared length when text was null.